### PR TITLE
Attributes - weak attribute addition

### DIFF
--- a/compiler-polyfill/attributes.h
+++ b/compiler-polyfill/attributes.h
@@ -31,10 +31,12 @@
         #define __unused __attribute__((__unused__))
     #endif
 
+    #ifndef __weak
+        #define __weak __attribute__((weak))
+    #endif
 #else
 // unknown compiler
     #error "this compiler is not yet supported by compiler-polyfill, if you can contribute support please submit a pull request at https://github.com/ARMmbed/compiler-polyfill"
 #endif
-
 
 #endif // ndef __COMPILER_POLYFILL_ATTRIBUTES_H__


### PR DESCRIPTION
Should fix #2 .

All attributes are now in place for mbed-drivers. There will be a new PR to mbed-drivers to remove toolchain header file we used to have there.

@autopulated @bogdanm 
