### PR TITLE
Added attributes to put data in uninitialized sections

### DIFF
--- a/compiler-polyfill/attributes.h
+++ b/compiler-polyfill/attributes.h
@@ -39,6 +39,14 @@
         #define __deprecated __attribute__((deprecated))
     #endif
 
+    #ifndef __uninitialized
+        #define __uninitialized __attribute__((section(".uninitialized")))
+    #endif
+
+    #ifndef __force_uninitialized
+        #define __force_uninitialized __attribute__((section(".keep.uninitialized")))
+    #endif
+
 #else
 // unknown compiler
     #error "this compiler is not yet supported by compiler-polyfill, if you can contribute support please submit a pull request at https://github.com/ARMmbed/compiler-polyfill"


### PR DESCRIPTION
Introducing the `__uninitialized` attribute to put data in an `.uninitialized` section in the linker script.
Using `__force_uninitialized` the variable is kept in the section even if unused.

See related:
https://github.com/ARMmbed/target-frdm-k64f-gcc/pull/18
https://github.com/ARMmbed/target-st-stm32f429i-disco/pull/21
https://github.com/ARMmbed/target-st-stm32f439zi-gcc/pull/5

@bogdanm @autopulated @0xc0170 @meriac 
