### PR TITLE
Add deprecated message macro.

### DIFF
--- a/compiler-polyfill/attributes.h
+++ b/compiler-polyfill/attributes.h
@@ -39,6 +39,10 @@
         #define __deprecated __attribute__((deprecated))
     #endif
 
+    #ifndef __deprecated_message
+        #define __deprecated_message(msg) __attribute__((deprecated(msg)))
+    #endif
+
 #else
 // unknown compiler
     #error "this compiler is not yet supported by compiler-polyfill, if you can contribute support please submit a pull request at https://github.com/ARMmbed/compiler-polyfill"


### PR DESCRIPTION
Usage: `__deprecated_message("Use foo instead.")`.

It was discussed to name this `__deprecated_reason(msg)`, however, the reasoning behind the deprecation may be quite long and probably not very useful to the user.
A message on how to mitigate the deprecation seems to be more useful and is very likely shorter.
A detailed reason can still be put into the doxygen documentation, and the developer can look at it voluntarily.

Works on GCC, Clang and also on armcc in GNU mode.

In C++14 this could be transparently translated to `[[deprecated(msg)]]`.

@bogdanm @hugovincent @autopulated 
