### PR TITLE
Improve testing documentation and compatibility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ yotta_targets
 yotta_modules
 upload.tar.gz
 .DS_Store
+.yotta.json

--- a/.yotta_ignore
+++ b/.yotta_ignore
@@ -1,0 +1,1 @@
+test/attributes

--- a/compiler-polyfill/attributes.h
+++ b/compiler-polyfill/attributes.h
@@ -31,21 +31,9 @@
         #define __unused __attribute__((__unused__))
     #endif
     
-    // __weak has a different meaning on objc: when included from objc code
-    // don't define it
-    #ifndef __OBJC__
-        #ifdef __APPLE__
-            // when compiling for OS X (and not compiling objective-c code)
-            // replace the built-in __weak gc attribute with a weak-linking
-            // attribute
-            #undef __weak
-            #define __weak __attribute__((weak))
-        #else
-            #ifndef __weak
-                #define __weak __attribute__((weak))
-            #endif
-        #endif
-    #endif // ndef __OBJC__
+    #ifndef __weak
+        #define __weak __attribute__((weak))
+    #endif
 
     #ifndef __deprecated
         #define __deprecated __attribute__((deprecated))

--- a/compiler-polyfill/attributes.h
+++ b/compiler-polyfill/attributes.h
@@ -30,10 +30,22 @@
     #ifndef __unused
         #define __unused __attribute__((__unused__))
     #endif
-
-    #ifndef __weak
-        #define __weak __attribute__((weak))
-    #endif
+    
+    // __weak has a different meaning on objc: when included from objc code
+    // don't define it
+    #ifndef __OBJC__
+        #ifdef __APPLE__
+            // when compiling for OS X (and not compiling objective-c code)
+            // replace the built-in __weak gc attribute with a weak-linking
+            // attribute
+            #undef __weak
+            #define __weak __attribute__((weak))
+        #else
+            #ifndef __weak
+                #define __weak __attribute__((weak))
+            #endif
+        #endif
+    #endif // ndef __OBJC__
 
     #ifndef __deprecated
         #define __deprecated __attribute__((deprecated))

--- a/compiler-polyfill/attributes.h
+++ b/compiler-polyfill/attributes.h
@@ -52,7 +52,12 @@
     #endif
 
     #ifndef __deprecated_message
-        #define __deprecated_message(msg) __attribute__((deprecated(msg)))
+        #if defined(__CC_ARM)
+            // no argument support in armcc
+            #define __deprecated_message(msg) __attribute__((deprecated))
+        #else
+            #define __deprecated_message(msg) __attribute__((deprecated(msg)))
+        #endif
     #endif
 
 #else

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,42 @@ Declare a function argument to be unused, suppressing compiler warnings.
 void foo(int __unused arg){
     
 }
-
 ```
 
+##### `__weak`
+Mark a function as being weak.
 
+**Note:** weak functions are not friendly to making code re-usable, as they can
+only be overridden once (and if they are multiply overridden the linker will
+emit no warning). You should not normally use weak symbols as part of the API
+to re-usable yotta modules.
+
+```C
+#include "compiler-polyfill/attributes.h"
+
+void __weak foo() {
+    // a weak implementation of foo that can be overriden by a definition
+    // without  __weak
+}
+```
+
+##### `__deprecated`
+Mark a function declaration as deprecated, if it used then a warning will be
+issued by the compiler.
+
+```C
+#include "compiler-polyfill/attributes.h"
+
+void foo(int arg) __deprecated;
+```
+
+##### `__deprecated_message("message string")`
+Mark a function declaration as deprecated, if it used then a warning will be
+issued by the compiler possibly including the provided message. Note that not
+all compilers are able to display the message.
+
+```C
+#include "compiler-polyfill/attributes.h"
+
+void foo(int arg) __deprecated_message("don't foo any more, bar instead");
+```

--- a/test/attributes/attributes.c
+++ b/test/attributes/attributes.c
@@ -1,5 +1,5 @@
 /* compiler-polyfill
- * Copyright (c) 2014 ARM Limited
+ * Copyright (c) 2014-2015 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,33 @@ int testUnused(int __unused arg){
     return 0;
 }
 
+void testDeprecatedUnused() __deprecated;
+void testDeprecatedUnused(){ }
+
+int testDeprecatedUsed() __deprecated;
+int testDeprecatedUsed(){
+    return 0;
+}
+
+void testDeprecatedUnusedMessage() __deprecated_message("this message should not be displayed"); 
+void testDeprecatedUnusedMessage(){ }
+
+int testDeprecatedUsedMessage() __deprecated_message("this message should be displayed");
+int testDeprecatedUsedMessage(){
+    return 0;
+}
+
+
+int testWeak1();
+int testWeak2();
+
+int testWeak2(){
+    return 0;
+}
+
+int __weak testWeak1() {
+    return 1;
+}
 
 int main(){
     int failed = 0;
@@ -87,6 +114,10 @@ int main(){
     failed += testPacked();
     failed += testAlign();
     failed += testUnused(0);
+    failed += testDeprecatedUsed();
+    failed += testWeak1();
+    failed += testWeak2();
+    failed += testDeprecatedUsedMessage();
 
     return failed;
 }

--- a/test/attributes/weak.c
+++ b/test/attributes/weak.c
@@ -1,0 +1,26 @@
+/* compiler-polyfill
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "compiler-polyfill/attributes.h"
+
+int testWeak1() {
+    return 0;
+}
+
+int __weak testWeak2() {
+    return 1;
+}
+


### PR DESCRIPTION
- Explicitly redefine __weak on OS X if not building objective-c code.
- Add missing documentation to readme
- Add missing functionality to test/attributes, and move the test into a
  subfolder. Note that the test is ignored in .yotta_ignore as it (by design)
  produces compiler warnings, but can be re-enabled as desired.

@0xc0170 @niklas-arm @bogdanm 

The one thing I'm not sure about here is redefining __weak on OS X: might revert that and do a separate PR, everything else should be 100% backwards compatible.
