### PR TITLE
redefine __weak on OS X to mean weak-linking not weak-gc

### DIFF
--- a/compiler-polyfill/attributes.h
+++ b/compiler-polyfill/attributes.h
@@ -31,9 +31,21 @@
         #define __unused __attribute__((__unused__))
     #endif
     
-    #ifndef __weak
-        #define __weak __attribute__((weak))
-    #endif
+    // __weak has a different meaning on objc: when included from objc code
+    // don't define it
+    #ifndef __OBJC__
+        #ifdef __APPLE__
+            // when compiling for OS X (and not compiling objective-c code)
+            // replace the built-in __weak gc attribute with a weak-linking
+            // attribute
+            #undef __weak
+            #define __weak __attribute__((weak))
+        #else
+            #ifndef __weak
+                #define __weak __attribute__((weak))
+            #endif
+        #endif
+    #endif // ndef __OBJC__
 
     #ifndef __deprecated
         #define __deprecated __attribute__((deprecated))


### PR DESCRIPTION
This makes the test pass on OS X. I don't think the adverse consequences would be severe, but this is a breaking change. @marcuschangarm, @thegecko could you confirm if you think this would break anything?
